### PR TITLE
[FIX] *: Change Date to string

### DIFF
--- a/app/components/Transaction/TransactionCard.tsx
+++ b/app/components/Transaction/TransactionCard.tsx
@@ -7,12 +7,13 @@ export interface TransactionCardProps {
   category: string;
   description: string;
   icon: number;
-  date: Date;
+  date: string;
   uuid: string;
   className?: string;
 }
 
 const TransactionCard = ({ amount, category, description, icon, date, uuid, className }: TransactionCardProps) => {
+  const date_date = new Date(date);
   function getUrl() {
     return `/transactions/${uuid}`;
   }
@@ -21,7 +22,7 @@ const TransactionCard = ({ amount, category, description, icon, date, uuid, clas
     <Link to={getUrl()} className={`${className} bg-white flex lg:max-w-xl h-14 border
       rounded-lg drop-shadow-sm hover:border-gray-400`}>
       <div className="hidden md:w-28 md:flex md:justify-start md:items-center p-1">
-        <p className="text-base truncate block font-normal">{date.toLocaleDateString("pt-BR")}</p>
+        <p className="text-base truncate block font-normal">{date_date.toLocaleDateString("pt-BR")}</p>
       </div>
       <div className="w-10 flex justify-center items-center">
         <div className="bg-wallet_gray p-2 rounded-full">

--- a/app/helper/dateFormatter/formatLongMonth.tsx
+++ b/app/helper/dateFormatter/formatLongMonth.tsx
@@ -1,7 +1,8 @@
-export function formatLongMonth(date: Date) {
-  const month = date.toLocaleString("en-US", { month: "long"});
-  const day = date.getDate();
-  const year = date.getFullYear();
+export function formatLongMonth(date: string) {
+  const date_date = new Date(date);
+  const month = date_date.toLocaleString("en-US", { month: "long"});
+  const day = date_date.getDate();
+  const year = date_date.getFullYear();
   const now = new Date();
 
   if (year != now.getFullYear()) return `${month}, ${day}. ${year}`;

--- a/app/helper/dateFormatter/formatSlashDivision.tsx
+++ b/app/helper/dateFormatter/formatSlashDivision.tsx
@@ -1,7 +1,8 @@
-export function formatSlashDivision(date: Date) {
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const year = date.getFullYear();
+export function formatSlashDivision(date: string) {
+  const date_date = new Date(date);
+  const month = date_date.getMonth() + 1;
+  const day = date_date.getDate();
+  const year = date_date.getFullYear();
 
   const str_month = month > 9 ? month.toString() : `0${month.toString()}`;
   const str_day = day > 9 ? day.toString() : `0${day.toString()}`;

--- a/app/routes/finance/transactions/show.tsx
+++ b/app/routes/finance/transactions/show.tsx
@@ -57,7 +57,8 @@ export default function Transaction() {
   const [mounted, setMounted] = useState(false);
   const [visible, setVisible] = useState(false);
 
-  const [date, setDate] = useState(transaction.date.toISOString().split("T")[0]);
+  const transaction_date_date = new Date(transaction.date);
+  const [date, setDate] = useState(transaction_date_date.toISOString().split("T")[0]);
   const [showCategorySelection, setShowCategorySelection] = useState(false);
   const [footerState, setFooterState] = useState<'options' | 'deleting' | 'editing' | 'blocked'>(
     (new Date(planning.startDate) > transaction.date ? 'blocked' : 'options')
@@ -107,7 +108,7 @@ export default function Transaction() {
     formRef.current?.reset();
     setFooterState('options');
     setCategory(originalCategory);
-    setDate(transaction.date.toISOString().split("T")[0]);
+    setDate(transaction_date_date.toISOString().split("T")[0]);
   }
 
   const handleSave = () => {

--- a/app/services/transactions/getTransaction.server.ts
+++ b/app/services/transactions/getTransaction.server.ts
@@ -10,7 +10,7 @@ export default async function GetTransaction(token: string, uuid: string) {
   const t: RawTransaction = await response?.json();
   return {
     description: t.description,
-    date: new Date(t.occurred_at),
+    date: t.occurred_at,
     amount: Number(t.value),
     currency: t.currency,
     category: t.category_name,

--- a/app/services/transactions/getTransactions.server.ts
+++ b/app/services/transactions/getTransactions.server.ts
@@ -14,7 +14,7 @@ export default async function GetTransactions(token: string, currency: string) {
     (t: RawTransaction) => {
       return {
         description: t.description,
-        date: new Date(t.occurred_at),
+        date: t.occurred_at,
         amount: Number(t.value),
         currency: t.currency,
         category: t.category_name,

--- a/app/types/transaction.ts
+++ b/app/types/transaction.ts
@@ -1,6 +1,6 @@
 export interface Transaction {
     description: string;
-    date: Date;
+    date: string;
     amount: number;
     currency: string;
     category: string;


### PR DESCRIPTION
Parsing Date format to string.

When a request is passed via loader to the client, the dates with Date format was not being parsed
correctly, and it was delivering string types instead of Date one. This commit fixes it, receving string in all dates references and parsing to Date explicitly to avoid access Date methods from a string.